### PR TITLE
[FMT] Apply `black==22.10.0`, support `python3.7+`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,10 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     env:
-      USING_COVERAGE: '3.6,3.8'
+      USING_COVERAGE: '3.7,3.8'
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 #+title: unfoldNd: N-dimensional unfold in PyTorch
 
 [[https://coveralls.io/repos/github/f-dangel/unfoldNd/badge.svg?branch=main]]
-[[https://img.shields.io/badge/python-3.6+-blue.svg]]
+[[https://img.shields.io/badge/python-3.7+-blue.svg]]
 
 This package uses a numerical trick to perform the operations of [[https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.unfold][ ~torch.nn.functional.unfold~ ]] and [[https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html][ ~torch.nn.Unfold~ ]], also known as ~im2col~. It extends them to higher-dimensional inputs that are currently not supported.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.extras_require]
 # Dependencies needed to run the tests (semicolon/line-separated)

--- a/test/fold_settings.py
+++ b/test/fold_settings.py
@@ -42,9 +42,9 @@ PRECISION_PROBLEMS_2D = [
         "fold_kwargs": {
             # > smallest int which is exact as float32, 2 ** 24 = 116777217
             # (see https://stackoverflow.com/q/27207149 for details)
-            "output_size": (2 ** 12 + 2, 2 ** 12 + 2),
+            "output_size": (2**12 + 2, 2**12 + 2),
             "kernel_size": (2, 2),
-            "stride": 2 ** 10,
+            "stride": 2**10,
         },
     },
     # wrong result due to wrong float → long conversion


### PR DESCRIPTION
The latest PyTorch version dropped support for `python3.6`. To keep up-to-date with latest PyTorch and python versions, `python3.6` won't be supported in future versions of this library.