### PR TITLE
Port package version discovery from pkg_resources [deprecated] to importlib+distutils

### DIFF
--- a/.conda_env.yml
+++ b/.conda_env.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - pip=19.3.1
-  - python=3.7.6
+  - python=3.8.19
   - pip:
     - -e .[lint]
     - -e .[test]

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-black.yaml
+++ b/.github/workflows/lint-black.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-darglint.yaml
+++ b/.github/workflows/lint-darglint.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-flake8.yaml
+++ b/.github/workflows/lint-flake8.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-isort.yaml
+++ b/.github/workflows/lint-isort.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint-pydocstyle.yaml
+++ b/.github/workflows/lint-pydocstyle.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,11 @@ jobs:
     name: "py${{ matrix.python-version }} torch${{ matrix.pytorch-version }}"
     runs-on: ubuntu-latest
     env:
-      USING_COVERAGE: '3.7,3.9'
+      USING_COVERAGE: '3.8,3.9'
     strategy:
       matrix:
         python-version:
-          - "3.7"
+          - "3.8"
           - "3.9"
         pytorch-version:
           - "==1.9.1"

--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 #+title: unfoldNd: N-dimensional unfold in PyTorch
 
 [[https://coveralls.io/repos/github/f-dangel/unfoldNd/badge.svg?branch=main]]
-[[https://img.shields.io/badge/python-3.7+-blue.svg]]
+[[https://img.shields.io/badge/python-3.8+-blue.svg]]
 
 This package uses a numerical trick to perform the operations of [[https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.unfold][ ~torch.nn.functional.unfold~ ]] and [[https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html][ ~torch.nn.Unfold~ ]], also known as ~im2col~. It extends them to higher-dimensional inputs that are currently not supported.
 

--- a/black.toml
+++ b/black.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +36,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 # Dependencies needed to run the tests (semicolon/line-separated)

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,16 +68,24 @@ max-line-length = 80
 max-complexity = 10
 ignore =
 	# replaced by B950 (max-line-length + 10%)
-	E501, # max-line-length
+    # max-line-length
+	E501,
 	# ignored because pytorch uses dict
-	C408, # use {} instead of dict()
+    # use {} instead of dict()
+	C408,
 	# Not Black-compatible
-	E203, # whitespace before :
-	E231, # missing whitespace after ','
-	W291, # trailing whitespace
-	W503, # line break before binary operator
-	W504, # line break after binary operator
-	B905, # `zip()` without an explicit `strict=` parameter
+    # whitespace before :
+	E203,
+    # missing whitespace after ','
+	E231,
+    # trailing whitespace
+	W291,
+    # line break before binary operator
+	W503,
+    # line break after binary operator
+	W504,
+    # `zip()` without an explicit `strict=` parameter
+	B905,
 exclude = docs, docs_src, build, .git, .eggs
 
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,20 @@ Use setup.cfg to configure the project.
 """
 
 import sys
+from distutils.version import LooseVersion
+from importlib.metadata import PackageNotFoundError, version
 
-from pkg_resources import VersionConflict, require
 from setuptools import setup
 
 try:
-    require("setuptools>=38.3")
-except VersionConflict:
-    print("Error: version of setuptools is too old (<38.3)!")
+    setuptools_version = LooseVersion(version("setuptools"))
+    required_version = LooseVersion("38.3")
+    if setuptools_version < required_version:
+        print("Error: version of setuptools is too old (<38.3)!")
+        sys.exit(1)
+except PackageNotFoundError:
+    print("setuptools not found")
     sys.exit(1)
-
 
 if __name__ == "__main__":
     setup(use_scm_version=True)

--- a/unfoldNd/__init__.py
+++ b/unfoldNd/__init__.py
@@ -1,6 +1,5 @@
 """unfoldNd library."""
 
-
 from unfoldNd.fold import FoldNd, foldNd
 from unfoldNd.unfold import UnfoldNd, unfoldNd
 from unfoldNd.unfold_transpose import UnfoldTransposeNd, unfold_transposeNd

--- a/unfoldNd/utils.py
+++ b/unfoldNd/utils.py
@@ -1,9 +1,10 @@
 """Shared utility functions."""
 
+from distutils.version import LooseVersion
+from importlib.metadata import version
 from typing import Callable
 
 import numpy
-from pkg_resources import get_distribution, packaging
 from torch.nn.functional import (
     conv1d,
     conv2d,
@@ -14,8 +15,8 @@ from torch.nn.functional import (
 )
 from torch.nn.modules.utils import _pair, _single, _triple
 
-TORCH_VERSION = packaging.version.parse(get_distribution("torch").version)
-TORCH_VERSION_AT_LEAST_1_12_0 = TORCH_VERSION >= packaging.version.parse("1.12.0")
+TORCH_VERSION = LooseVersion(version("torch"))
+TORCH_VERSION_AT_LEAST_1_12_0 = TORCH_VERSION >= LooseVersion("1.12.0")
 
 
 def _get_kernel_size_numel(kernel_size):


### PR DESCRIPTION
A quick fix for "ImportError: No module named pkg_resources".

Context: "Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions." - https://setuptools.pypa.io/en/latest/pkg_resources.html

Thank you for your work on the library!