### PR TITLE
[REF] Port package version comparison from `distutils` [deprecated] to `packaging`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Switch from `distutils` (deprecated) to `packaging`
+
 ## [0.2.2] - 2024-06-14
 
 - Switch from `pkg_resources` (deprecated) to `importlib`+`distutils`, deprecate

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Switch from `distutils` (deprecated) to `packaging`
+  [[PR](https://github.com/f-dangel/unfoldNd/pull/39)]
 
 ## [0.2.2] - 2024-06-14
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,12 @@ zip_safe = False
 packages = find:
 include_package_data = True
 setup_requires =
+  packaging
+  setuptools>=38.3
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
+    packaging
     torch
     numpy
 # The usage of test_requires is discouraged, see `Dependency Management` docs

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ Use setup.cfg to configure the project.
 """
 
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 from importlib.metadata import PackageNotFoundError, version
 
 from setuptools import setup
 
 try:
-    setuptools_version = LooseVersion(version("setuptools"))
-    required_version = LooseVersion("38.3")
+    setuptools_version = Version(version("setuptools"))
+    required_version = Version("38.3")
     if setuptools_version < required_version:
         print("Error: version of setuptools is too old (<38.3)!")
         sys.exit(1)

--- a/unfoldNd/utils.py
+++ b/unfoldNd/utils.py
@@ -1,6 +1,6 @@
 """Shared utility functions."""
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from importlib.metadata import version
 from typing import Callable
 
@@ -15,8 +15,8 @@ from torch.nn.functional import (
 )
 from torch.nn.modules.utils import _pair, _single, _triple
 
-TORCH_VERSION = LooseVersion(version("torch"))
-TORCH_VERSION_AT_LEAST_1_12_0 = TORCH_VERSION >= LooseVersion("1.12.0")
+TORCH_VERSION = Version(version("torch"))
+TORCH_VERSION_AT_LEAST_1_12_0 = TORCH_VERSION >= Version("1.12.0")
 
 
 def _get_kernel_size_numel(kernel_size):


### PR DESCRIPTION
```
ModuleNotFoundError: No module named 'distutils'
```
distutils was removed in Python 3.12